### PR TITLE
Sel 543

### DIFF
--- a/app/components/Playground.tsx
+++ b/app/components/Playground.tsx
@@ -187,11 +187,11 @@ function Playground() {
                 <div className="flex items-center">
                     <div className="mr-8">
                         <Image 
-                            width={32}
-                            height={32}
+                            width={96}
+                            height={36}
                             src="/self.svg" 
                             alt="Self Logo" 
-                            className="h-8 w-8"
+                            className="h-9 w-24"
                         />
                     </div>
                 </div>

--- a/app/components/Playground.tsx
+++ b/app/components/Playground.tsx
@@ -183,9 +183,9 @@ function Playground() {
 
     return (
         <div className="App flex flex-col min-h-screen bg-white text-black" suppressHydrationWarning>
-            <nav className="w-full bg-white border-b border-gray-200 py-3 px-6 flex items-center justify-between">
+            <nav className="w-full bg-white border-b border-gray-200 py-3 px-4 sm:px-6 flex items-center justify-between">
                 <div className="flex items-center">
-                    <div className="mr-8">
+                    <div className="mr-4 sm:mr-8">
                         <Image 
                             width={96}
                             height={36}
@@ -195,15 +195,16 @@ function Playground() {
                         />
                     </div>
                 </div>
-                <div className="flex items-center space-x-4">
+                <div className="flex items-center space-x-2 sm:space-x-4">
                     <a 
                         href="https://github.com/selfxyz/self"
                         target="_blank" 
                         rel="noopener noreferrer" 
-                        className="bg-gray-900 text-white px-4 py-2 rounded-md flex items-center hover:bg-gray-800 transition-colors"
+                        className="bg-gray-900 text-white px-3 py-2 sm:px-4 sm:py-2 rounded-md flex items-center hover:bg-gray-800 transition-colors text-sm sm:text-base"
                     >
-                        <span className="mr-2">Star on Github</span>
-                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <span className="mr-1 sm:mr-2 hidden sm:inline">Star on Github</span>
+                        <span className="mr-1 sm:mr-2 sm:hidden">Star</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" className="sm:w-5 sm:h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                             <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
                         </svg>
                     </a>


### PR DESCRIPTION
## Fix logo aspect ratio and improve mobile navigation

### Changes
- **Fixed logo aspect ratio**: Changed from 32x32 square to correct 96x36 dimensions maintaining the original 192:72 SVG proportions
- **Mobile-responsive navigation**: Added responsive padding, spacing, and text sizing for better mobile experience
- **Adaptive button text**: Shows "Star" on mobile, "Star on Github" on desktop to save space
- **Responsive icon sizing**: Smaller icons on mobile (16px), larger on desktop (20px)