### PR TITLE
chore: lint/format setup, local in-memory config store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .claude/
+
+# lint caches
+.eslintcache

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+node_modules/
+.next/
+out/
+build/
+dist/
+public/
+*.md
+yarn.lock
+package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ public/
 *.md
 yarn.lock
 package-lock.json
+next-env.d.ts

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,19 @@
+{
+  "arrowParens": "avoid",
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "endOfLine": "auto",
+  "overrides": [
+    {
+      "files": ["*.yml", "*.yaml"],
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}

--- a/Self Fontbook 2/Advercase/advercase-bold/advercase-bold.css
+++ b/Self Fontbook 2/Advercase/advercase-bold/advercase-bold.css
@@ -15,13 +15,14 @@ License: 	The WebFont(s) listed in this document must follow the YouWorkForThem
 */
 
 @font-face {
-	font-family: 'Advercase-Bold';
-	src: url('advercase-bold.eot');
-	src: url('advercase-bold.eot?#iefix') format('embedded-opentype'),
-             url('advercase-bold.woff2') format('woff2'),
-	     url('advercase-bold.woff') format('woff'),
-	     url('advercase-bold.ttf') format('truetype'),
-	     url('advercase-bold.svg#youworkforthem') format('svg');
-	font-weight: normal;
-	font-style: normal;
+  font-family: 'Advercase-Bold';
+  src: url('advercase-bold.eot');
+  src:
+    url('advercase-bold.eot?#iefix') format('embedded-opentype'),
+    url('advercase-bold.woff2') format('woff2'),
+    url('advercase-bold.woff') format('woff'),
+    url('advercase-bold.ttf') format('truetype'),
+    url('advercase-bold.svg#youworkforthem') format('svg');
+  font-weight: normal;
+  font-style: normal;
 }

--- a/Self Fontbook 2/Advercase/advercase-regular/advercase-regular.css
+++ b/Self Fontbook 2/Advercase/advercase-regular/advercase-regular.css
@@ -15,13 +15,14 @@ License: 	The WebFont(s) listed in this document must follow the YouWorkForThem
 */
 
 @font-face {
-	font-family: 'Advercase-Regular';
-	src: url('advercase-regular.eot');
-	src: url('advercase-regular.eot?#iefix') format('embedded-opentype'),
-             url('advercase-regular.woff2') format('woff2'),
-	     url('advercase-regular.woff') format('woff'),
-	     url('advercase-regular.ttf') format('truetype'),
-	     url('advercase-regular.svg#youworkforthem') format('svg');
-	font-weight: normal;
-	font-style: normal;
+  font-family: 'Advercase-Regular';
+  src: url('advercase-regular.eot');
+  src:
+    url('advercase-regular.eot?#iefix') format('embedded-opentype'),
+    url('advercase-regular.woff2') format('woff2'),
+    url('advercase-regular.woff') format('woff'),
+    url('advercase-regular.ttf') format('truetype'),
+    url('advercase-regular.svg#youworkforthem') format('svg');
+  font-weight: normal;
+  font-style: normal;
 }

--- a/app/components/CircleCheckbox.tsx
+++ b/app/components/CircleCheckbox.tsx
@@ -3,27 +3,46 @@
 import React from 'react';
 
 interface CircleCheckboxProps {
-    checked: boolean;
-    onChange: () => void;
-    label: string;
+  checked: boolean;
+  onChange: () => void;
+  label: string;
 }
 
-export default function CircleCheckbox({ checked, onChange, label }: CircleCheckboxProps) {
-    return (
-        <label className="flex items-center gap-[6px] cursor-pointer select-none" onClick={onChange}>
-            <div className="flex items-center justify-center shrink-0 w-[20px] h-[19px]">
-                {checked ? (
-                    <svg width="20" height="19" viewBox="0 0 20 19" fill="none">
-                        <circle cx="10" cy="9.5" r="9" fill="#2563EB" />
-                        <path d="M6 9.5L9 12.5L14.5 7" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                ) : (
-                    <svg width="20" height="19" viewBox="0 0 20 19" fill="none">
-                        <circle cx="10" cy="9.5" r="8.5" stroke="#CBD5E1" strokeWidth="1.5" />
-                    </svg>
-                )}
-            </div>
-            <span className="text-[14px] text-black">{label}</span>
-        </label>
-    );
+export default function CircleCheckbox({
+  checked,
+  onChange,
+  label,
+}: CircleCheckboxProps) {
+  return (
+    <label
+      className="flex items-center gap-[6px] cursor-pointer select-none"
+      onClick={onChange}
+    >
+      <div className="flex items-center justify-center shrink-0 w-[20px] h-[19px]">
+        {checked ? (
+          <svg width="20" height="19" viewBox="0 0 20 19" fill="none">
+            <circle cx="10" cy="9.5" r="9" fill="#2563EB" />
+            <path
+              d="M6 9.5L9 12.5L14.5 7"
+              stroke="white"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : (
+          <svg width="20" height="19" viewBox="0 0 20 19" fill="none">
+            <circle
+              cx="10"
+              cy="9.5"
+              r="8.5"
+              stroke="#CBD5E1"
+              strokeWidth="1.5"
+            />
+          </svg>
+        )}
+      </div>
+      <span className="text-[14px] text-black">{label}</span>
+    </label>
+  );
 }

--- a/app/components/Playground.tsx
+++ b/app/components/Playground.tsx
@@ -7,12 +7,14 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { countries } from '@selfxyz/qrcode';
 import type {
-  type Country3LetterCode,
+  Country3LetterCode,
+  SelfApp,
+  SelfAppDisclosureConfig,
+} from '@selfxyz/sdk-common';
+import {
   countryCodes,
   getUniversalLink,
-  type SelfApp,
   SelfAppBuilder,
-  SelfAppDisclosureConfig,
 } from '@selfxyz/sdk-common';
 
 import CircleCheckbox from './CircleCheckbox';

--- a/app/components/Playground.tsx
+++ b/app/components/Playground.tsx
@@ -1,669 +1,825 @@
 'use client';
 
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import dynamic from 'next/dynamic';
-import { v4 as uuidv4 } from 'uuid';
-import { countryCodes, SelfAppDisclosureConfig, type Country3LetterCode, SelfAppBuilder, getUniversalLink, type SelfApp } from '@selfxyz/sdk-common';
-import { countries } from '@selfxyz/qrcode';
 import Image from 'next/image';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { countries } from '@selfxyz/qrcode';
+import type {
+  type Country3LetterCode,
+  countryCodes,
+  getUniversalLink,
+  type SelfApp,
+  SelfAppBuilder,
+  SelfAppDisclosureConfig,
+} from '@selfxyz/sdk-common';
+
 import CircleCheckbox from './CircleCheckbox';
 import SectionLabel from './SectionLabel';
 
 const SelfQRcodeWrapper = dynamic(
-    () => import('@selfxyz/qrcode').then((mod) => mod.SelfQRcodeWrapper),
-    { ssr: false }
+  () => import('@selfxyz/qrcode').then(mod => mod.SelfQRcodeWrapper),
+  { ssr: false },
 );
 
 const SelfDeepLinkButton = dynamic(
-    () => import('@selfxyz/qrcode').then((mod) => mod.SelfDeepLinkButton),
-    { ssr: false }
+  () => import('@selfxyz/qrcode').then(mod => mod.SelfDeepLinkButton),
+  { ssr: false },
 );
 
 function Playground() {
-    const [userId, setUserId] = useState<string | null>(null);
-    const [savingOptions, setSavingOptions] = useState(false);
-    const [universalLink, setUniversalLink] = useState('');
-    const [token, setToken] = useState<string | null>(null);
-    const [isFetchingToken, setIsFetchingToken] = useState(false);
-    const [appName, setAppName] = useState('Self Playground');
-    const [appIconUrl, setAppIconUrl] = useState('https://image2url.com/r2/default/images/1772123009674-14365df5-cc03-433d-9c21-814d43ad2fb8.png');
-    const [previewTab, setPreviewTab] = useState<'desktop' | 'mobile' | 'alternates' | 'code'>('desktop');
+  const [userId, setUserId] = useState<string | null>(null);
+  const [savingOptions, setSavingOptions] = useState(false);
+  const [universalLink, setUniversalLink] = useState('');
+  const [token, setToken] = useState<string | null>(null);
+  const [isFetchingToken, setIsFetchingToken] = useState(false);
+  const [appName, setAppName] = useState('Self Playground');
+  const [appIconUrl, setAppIconUrl] = useState(
+    'https://image2url.com/r2/default/images/1772123009674-14365df5-cc03-433d-9c21-814d43ad2fb8.png',
+  );
+  const [previewTab, setPreviewTab] = useState<
+    'desktop' | 'mobile' | 'alternates' | 'code'
+  >('desktop');
 
-    useEffect(() => {
-        const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-        if (isMobile) {
-            setPreviewTab('mobile');
-        }
-    }, []);
+  useEffect(() => {
+    const isMobile =
+      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        navigator.userAgent,
+      );
+    if (isMobile) {
+      setPreviewTab('mobile');
+    }
+  }, []);
 
-    useEffect(() => {
-        setUserId(uuidv4());
-    }, []);
+  useEffect(() => {
+    setUserId(uuidv4());
+  }, []);
 
-    const [disclosures, setDisclosures] = useState<SelfAppDisclosureConfig>({
-        issuing_state: false,
-        name: false,
-        nationality: true,
-        date_of_birth: false,
-        passport_number: false,
-        gender: false,
-        expiry_date: false,
-        minimumAge: 18,
-        excludedCountries: [
-            countries.IRAN,
-            countries.IRAQ,
-            countries.NORTH_KOREA,
-            countries.RUSSIA,
-            countries.SYRIAN_ARAB_REPUBLIC,
-            countries.VENEZUELA
-        ] as Country3LetterCode[],
-        ofac: true,
+  const [disclosures, setDisclosures] = useState<SelfAppDisclosureConfig>({
+    issuing_state: false,
+    name: false,
+    nationality: true,
+    date_of_birth: false,
+    passport_number: false,
+    gender: false,
+    expiry_date: false,
+    minimumAge: 18,
+    excludedCountries: [
+      countries.IRAN,
+      countries.IRAQ,
+      countries.NORTH_KOREA,
+      countries.RUSSIA,
+      countries.SYRIAN_ARAB_REPUBLIC,
+      countries.VENEZUELA,
+    ] as Country3LetterCode[],
+    ofac: true,
+  });
+
+  const [showCountryModal, setShowCountryModal] = useState(false);
+  const [selectedCountries, setSelectedCountries] = useState<
+    Country3LetterCode[]
+  >([
+    countries.IRAN,
+    countries.IRAQ,
+    countries.NORTH_KOREA,
+    countries.RUSSIA,
+    countries.SYRIAN_ARAB_REPUBLIC,
+    countries.VENEZUELA,
+  ]);
+  const [countrySelectionError, setCountrySelectionError] = useState<
+    string | null
+  >(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showIconPopover, setShowIconPopover] = useState(false);
+  const [iconUrlInput, setIconUrlInput] = useState(appIconUrl);
+
+  const incrementAge = () => {
+    setDisclosures(prev => ({
+      ...prev,
+      minimumAge: Math.min(99, (prev.minimumAge || 0) + 1),
+    }));
+  };
+
+  const decrementAge = () => {
+    setDisclosures(prev => ({
+      ...prev,
+      minimumAge: Math.max(0, (prev.minimumAge || 0) - 1),
+    }));
+  };
+
+  const handleCountryToggle = (country: Country3LetterCode) => {
+    setSelectedCountries(prev => {
+      if (prev.includes(country)) {
+        setCountrySelectionError(null);
+        return prev.filter(c => c !== country);
+      }
+      if (prev.length >= 40) {
+        setCountrySelectionError('Maximum 40 countries can be excluded');
+        return prev;
+      }
+      return [...prev, country];
     });
+  };
 
-    const [showCountryModal, setShowCountryModal] = useState(false);
-    const [selectedCountries, setSelectedCountries] = useState<Country3LetterCode[]>([
-        countries.IRAN,
-        countries.IRAQ,
-        countries.NORTH_KOREA,
-        countries.RUSSIA,
-        countries.SYRIAN_ARAB_REPUBLIC,
-        countries.VENEZUELA
-    ]);
-    const [countrySelectionError, setCountrySelectionError] = useState<string | null>(null);
-    const [searchQuery, setSearchQuery] = useState('');
-    const [showIconPopover, setShowIconPopover] = useState(false);
-    const [iconUrlInput, setIconUrlInput] = useState(appIconUrl);
+  const saveCountrySelection = () => {
+    const codes = selectedCountries.map(countryName => {
+      const entry = Object.entries(countryCodes).find(
+        ([_, name]) => name === countryName,
+      );
+      return entry ? entry[0] : countryName.substring(0, 3).toUpperCase();
+    }) as Country3LetterCode[];
+    setDisclosures(prev => ({ ...prev, excludedCountries: codes }));
+    setShowCountryModal(false);
+  };
 
-    const incrementAge = () => {
-        setDisclosures(prev => ({
-            ...prev,
-            minimumAge: Math.min(99, (prev.minimumAge || 0) + 1)
-        }));
+  const handleCheckboxChange = (field: string) => {
+    setDisclosures(prev => ({
+      ...prev,
+      [field]: !prev[field as keyof typeof prev],
+    }));
+  };
+
+  const saveOptionsToServer = useCallback(async () => {
+    if (!userId) return;
+    setSavingOptions(true);
+    try {
+      const response = await fetch('/api/saveOptions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId,
+          options: {
+            minimumAge:
+              disclosures.minimumAge && disclosures.minimumAge > 0
+                ? disclosures.minimumAge
+                : undefined,
+            excludedCountries: disclosures.excludedCountries,
+            ofac: disclosures.ofac,
+            issuing_state: disclosures.issuing_state,
+            name: disclosures.name,
+            nationality: disclosures.nationality,
+            date_of_birth: disclosures.date_of_birth,
+            passport_number: disclosures.passport_number,
+            gender: disclosures.gender,
+            expiry_date: disclosures.expiry_date,
+          },
+        }),
+      });
+      console.log('saved options to server');
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to save options');
+      }
+    } catch (error) {
+      console.error('Error saving options:', error);
+      if (error instanceof Error && error.message) {
+        alert(error.message);
+      } else {
+        alert('Failed to save verification options. Please try again.');
+      }
+    } finally {
+      setSavingOptions(false);
+    }
+  }, [
+    userId,
+    disclosures.minimumAge,
+    disclosures.excludedCountries,
+    disclosures.ofac,
+    disclosures.issuing_state,
+    disclosures.name,
+    disclosures.nationality,
+    disclosures.date_of_birth,
+    disclosures.passport_number,
+    disclosures.gender,
+    disclosures.expiry_date,
+  ]);
+
+  const disclosuresKey = useMemo(
+    () => JSON.stringify(disclosures),
+    [disclosures],
+  );
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (userId) {
+        saveOptionsToServer();
+      }
+    }, 500);
+    return () => clearTimeout(timeoutId);
+  }, [userId, disclosuresKey, saveOptionsToServer]);
+
+  const selfApp = useMemo(() => {
+    if (!userId || !appName) return null;
+    const app = new SelfAppBuilder({
+      appName: appName,
+      scope: 'self-playground',
+      endpoint: 'https://playground.self.xyz/api/verify',
+      endpointType: 'https',
+      logoBase64: appIconUrl,
+      userId,
+      disclosures: {
+        ...disclosures,
+        minimumAge:
+          disclosures.minimumAge && disclosures.minimumAge > 0
+            ? disclosures.minimumAge
+            : undefined,
+      },
+      version: 2,
+      userDefinedData: 'hello from the playground',
+      devMode: false,
+    } as Partial<SelfApp>).build();
+    return app;
+  }, [userId, disclosures, appName, appIconUrl]);
+
+  useEffect(() => {
+    if (selfApp) {
+      setUniversalLink(getUniversalLink(selfApp));
+    }
+  }, [selfApp]);
+
+  const sendPayload = async () => {
+    try {
+      const response = await fetch('/api/deferredLinking', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          campaign_id: 'self-playground',
+          campaign_user_id: userId,
+          self_app: JSON.stringify(selfApp),
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch token: ${response.status}`);
+      }
+      const data = await response.json();
+      return data.data || '';
+    } catch (error) {
+      console.error('Error fetching token:', error);
+      return '';
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    const prefetch = async () => {
+      if (!userId || !universalLink) return;
+      if (token || isFetchingToken) return;
+      setIsFetchingToken(true);
+      const t = await sendPayload();
+      if (!cancelled) {
+        setToken(t || null);
+      }
+      setIsFetchingToken(false);
     };
-
-    const decrementAge = () => {
-        setDisclosures(prev => ({
-            ...prev,
-            minimumAge: Math.max(0, (prev.minimumAge || 0) - 1)
-        }));
+    prefetch();
+    return () => {
+      cancelled = true;
     };
+    // token/isFetchingToken are read via closure as a guard; adding them as deps would retrigger the prefetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, universalLink]);
 
-    const handleCountryToggle = (country: Country3LetterCode) => {
-        setSelectedCountries(prev => {
-            if (prev.includes(country)) {
-                setCountrySelectionError(null);
-                return prev.filter(c => c !== country);
-            }
-            if (prev.length >= 40) {
-                setCountrySelectionError('Maximum 40 countries can be excluded');
-                return prev;
-            }
-            return [...prev, country];
-        });
-    };
+  const openSelfApp = async () => {
+    if (!universalLink || !token) return;
+    const isMobile =
+      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        navigator.userAgent,
+      );
+    try {
+      await navigator.clipboard.writeText(token);
+    } catch (err) {
+      console.error('Clipboard copy failed:', err);
+      prompt('Copy this token manually:', token);
+    }
+    if (isMobile) {
+      location.href = universalLink;
+    } else {
+      window.open(universalLink, '_blank');
+    }
+  };
 
-    const saveCountrySelection = () => {
-        const codes = selectedCountries.map(countryName => {
-            const entry = Object.entries(countryCodes).find(([_, name]) => name === countryName);
-            return entry ? entry[0] : countryName.substring(0, 3).toUpperCase();
-        }) as Country3LetterCode[];
-        setDisclosures(prev => ({ ...prev, excludedCountries: codes }));
-        setShowCountryModal(false);
-    };
+  if (!userId) return null;
 
-    const handleCheckboxChange = (field: string) => {
-        setDisclosures(prev => ({
-            ...prev,
-            [field]: !prev[field as keyof typeof prev]
-        }));
-    };
+  const filteredCountries = Object.entries(countryCodes).filter(
+    ([_, country]) => country.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
 
-    const saveOptionsToServer = useCallback(async () => {
-        if (!userId) return;
-        setSavingOptions(true);
-        try {
-            const response = await fetch('/api/saveOptions', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    userId,
-                    options: {
-                        minimumAge: disclosures.minimumAge && disclosures.minimumAge > 0 ? disclosures.minimumAge : undefined,
-                        excludedCountries: disclosures.excludedCountries,
-                        ofac: disclosures.ofac,
-                        issuing_state: disclosures.issuing_state,
-                        name: disclosures.name,
-                        nationality: disclosures.nationality,
-                        date_of_birth: disclosures.date_of_birth,
-                        passport_number: disclosures.passport_number,
-                        gender: disclosures.gender,
-                        expiry_date: disclosures.expiry_date
-                    }
-                }),
-            });
-            console.log("saved options to server");
-            if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.message || 'Failed to save options');
-            }
-        } catch (error) {
-            console.error('Error saving options:', error);
-            if (error instanceof Error && error.message) {
-                alert(error.message);
-            } else {
-                alert('Failed to save verification options. Please try again.');
-            }
-        } finally {
-            setSavingOptions(false);
-        }
-    }, [userId, disclosures.minimumAge, disclosures.excludedCountries, disclosures.ofac, disclosures.issuing_state, disclosures.name, disclosures.nationality, disclosures.date_of_birth, disclosures.passport_number, disclosures.gender, disclosures.expiry_date]);
+  const previewTabs = [
+    { id: 'desktop' as const, label: 'Desktop', enabled: true },
+    { id: 'mobile' as const, label: 'Mobile', enabled: true },
+  ];
 
-    const disclosuresKey = useMemo(() => JSON.stringify(disclosures), [disclosures]);
+  return (
+    <div
+      className="flex flex-col min-h-screen bg-white text-slate-900 font-din"
+      suppressHydrationWarning
+    >
+      {/* Nav Bar */}
+      <nav className="w-full bg-white border-b border-[#e2e8f0] px-[12px] py-[10px] flex items-center gap-[12px] md:px-[20px] md:gap-[30px] overflow-clip shrink-0">
+        <div className="flex items-center shrink-0">
+          <Image
+            width={80}
+            height={30}
+            src="/self.svg"
+            alt="Self Logo"
+            className="h-[30px] w-[80px]"
+          />
+        </div>
+        <div className="flex-1 flex items-center gap-[8px]">
+          <span className="h-[36px] px-[16px] pt-[10px] pb-[14px] text-[14px] font-medium text-white bg-black rounded-[5px] flex items-center justify-center">
+            Playground
+          </span>
+          <a
+            href="https://docs.self.xyz/use-self/quickstart"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden md:flex h-[36px] px-[16px] pt-[10px] pb-[14px] text-[14px] font-medium text-[#64748b] rounded-[5px] hover:bg-slate-50 transition-colors items-center justify-center"
+          >
+            Guides
+          </a>
+        </div>
+        <div className="flex items-center gap-[8px] shrink-0">
+          <a
+            href="https://github.com/selfxyz/self"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden md:flex h-[36px] px-[16px] border border-[#e2e8f0] rounded-[5px] items-center gap-[10px] text-[14px] font-medium text-[#64748b] bg-white hover:bg-slate-50 transition-colors"
+          >
+            <span>Star on Github</span>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+            </svg>
+          </a>
+          <a
+            href="https://docs.self.xyz"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="h-[36px] px-[12px] md:px-[16px] py-[8px] bg-[#0f172a] text-white rounded-[6px] flex items-center text-[13px] md:text-[14px] font-bold hover:bg-slate-800 transition-colors"
+          >
+            Docs
+          </a>
+        </div>
+      </nav>
 
-    useEffect(() => {
-        const timeoutId = setTimeout(() => {
-            if (userId) {
-                saveOptionsToServer();
-            }
-        }, 500);
-        return () => clearTimeout(timeoutId);
-    }, [userId, disclosuresKey, saveOptionsToServer]);
+      {/* Main Content */}
+      <div className="flex-1 flex flex-col lg:flex-row pt-[10px] px-[12px] pb-[40px] md:pr-[20px] md:px-0 rounded-[10px] w-full">
+        {/* Left Column - Config */}
+        <div className="w-full lg:w-[530px] lg:shrink-0 overflow-y-auto flex flex-col gap-[20px] px-[16px] py-[30px] md:gap-[30px] md:px-[40px] md:py-[60px]">
+          {/* Title */}
+          <div className="pb-[20px]">
+            <h1 className="font-advercase text-[28px] font-normal text-black tracking-[1px]">
+              Proof Request Playground
+            </h1>
+            <p className="text-[14px] font-medium text-[#64748b] mt-[4px] max-w-[380px]">
+              Configure these parameters to dynamically generate a unique QR for
+              testing with the Self Mobile app in Dev Mode.
+            </p>
+          </div>
 
-    const selfApp = useMemo(() => {
-        if (!userId || !appName) return null;
-        const app = new SelfAppBuilder({
-            appName: appName,
-            scope: "self-playground",
-            endpoint: "https://playground.self.xyz/api/verify",
-            endpointType: "https",
-            logoBase64: appIconUrl,
-            userId,
-            disclosures: {
-                ...disclosures,
-                minimumAge: disclosures.minimumAge && disclosures.minimumAge > 0 ? disclosures.minimumAge : undefined,
-            },
-            version: 2,
-            userDefinedData: "hello from the playground",
-            devMode: false,
-        } as Partial<SelfApp>).build();
-        return app;
-    }, [userId, disclosures, appName, appIconUrl]);
+          {/* App Name */}
+          <div className="flex flex-col gap-[10px]">
+            <SectionLabel
+              label="Name of Test Application"
+              tooltip="This name appears in the Self app when users scan the QR code"
+            />
+            <div className="flex items-center h-[36px] px-[16px] border border-[#e2e8f0] rounded-[5px] bg-white shadow-[0px_2px_4px_0px_rgba(0,0,0,0.1)] gap-[10px]">
+              <input
+                type="text"
+                value={appName}
+                onChange={e => setAppName(e.target.value.slice(0, 54))}
+                className="flex-1 text-[14px] font-medium text-black bg-transparent focus:outline-none placeholder:text-[#94a3b8]"
+                placeholder="Multipass"
+                maxLength={54}
+              />
+              <span className="text-[12px] font-medium text-[#94a3b8] shrink-0">
+                54 character limit
+              </span>
+            </div>
+          </div>
 
-    useEffect(() => {
-        if (selfApp) {
-            setUniversalLink(getUniversalLink(selfApp));
-        }
-    }, [selfApp]);
-
-    const sendPayload = async () => {
-        try {
-            const response = await fetch('/api/deferredLinking', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    campaign_id: 'self-playground',
-                    campaign_user_id: userId,
-                    self_app: JSON.stringify(selfApp)
-                }),
-            });
-            if (!response.ok) {
-                throw new Error(`Failed to fetch token: ${response.status}`);
-            }
-            const data = await response.json();
-            return data.data || '';
-        } catch (error) {
-            console.error("Error fetching token:", error);
-            return '';
-        }
-    };
-
-    useEffect(() => {
-        let cancelled = false;
-        const prefetch = async () => {
-            if (!userId || !universalLink) return;
-            if (token || isFetchingToken) return;
-            setIsFetchingToken(true);
-            const t = await sendPayload();
-            if (!cancelled) {
-                setToken(t || null);
-            }
-            setIsFetchingToken(false);
-        };
-        prefetch();
-        return () => { cancelled = true; };
-    }, [userId, universalLink]);
-
-    const openSelfApp = async () => {
-        if (!universalLink || !token) return;
-        const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-        try {
-            await navigator.clipboard.writeText(token);
-        } catch (err) {
-            console.error("Clipboard copy failed:", err);
-            prompt("Copy this token manually:", token);
-        }
-        if (isMobile) {
-            location.href = universalLink;
-        } else {
-            window.open(universalLink, "_blank");
-        }
-    };
-
-    if (!userId) return null;
-
-    const filteredCountries = Object.entries(countryCodes).filter(([_, country]) =>
-        country.toLowerCase().includes(searchQuery.toLowerCase())
-    );
-
-    const previewTabs = [
-        { id: 'desktop' as const, label: 'Desktop', enabled: true },
-        { id: 'mobile' as const, label: 'Mobile', enabled: true },
-    ];
-
-    return (
-        <div className="flex flex-col min-h-screen bg-white text-slate-900 font-din" suppressHydrationWarning>
-            {/* Nav Bar */}
-            <nav className="w-full bg-white border-b border-[#e2e8f0] px-[12px] py-[10px] flex items-center gap-[12px] md:px-[20px] md:gap-[30px] overflow-clip shrink-0">
-                <div className="flex items-center shrink-0">
-                    <Image width={80} height={30} src="/self.svg" alt="Self Logo" className="h-[30px] w-[80px]" />
+          {/* App Icon */}
+          <div className="flex flex-col gap-[10px]">
+            <SectionLabel
+              label="Test Application Icon"
+              tooltip="Icon displayed alongside your app name"
+            />
+            <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-[6px] flex gap-[12px] items-end overflow-clip pb-[20px] pl-[20px] pt-[50px] relative">
+              <div className="flex-1 flex flex-col gap-[12px] items-start pr-[30px] max-w-[220px]">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={appIconUrl}
+                  alt="App icon"
+                  width={36}
+                  height={36}
+                  className="w-[36px] h-[36px] rounded-[3px] shrink-0 object-cover"
+                />
+                <div className="flex flex-col gap-[12px] w-full">
+                  <button
+                    onClick={() => {
+                      setIconUrlInput(appIconUrl);
+                      setShowIconPopover(prev => !prev);
+                    }}
+                    className="h-[36px] px-[16px] text-[14px] font-medium bg-black text-white rounded-[5px] hover:bg-slate-800 transition-colors shrink-0 w-fit"
+                  >
+                    Replace icon
+                  </button>
+                  <p className="text-[12px] font-medium text-[#94a3b8]">
+                    400 x 400 pixels. Displayed to users during proof requests.
+                  </p>
                 </div>
-                <div className="flex-1 flex items-center gap-[8px]">
-                    <span className="h-[36px] px-[16px] pt-[10px] pb-[14px] text-[14px] font-medium text-white bg-black rounded-[5px] flex items-center justify-center">Playground</span>
-                    <a href="https://docs.self.xyz/use-self/quickstart" target="_blank" rel="noopener noreferrer" className="hidden md:flex h-[36px] px-[16px] pt-[10px] pb-[14px] text-[14px] font-medium text-[#64748b] rounded-[5px] hover:bg-slate-50 transition-colors items-center justify-center">Guides</a>
+              </div>
+              <Image
+                src="/phone.png"
+                alt="Phone mockup preview"
+                width={968}
+                height={784}
+                className="absolute right-0 bottom-0 h-full w-auto object-contain"
+              />
+            </div>
+          </div>
+
+          {/* Personal Information */}
+          <div className="flex flex-col gap-[10px]">
+            <SectionLabel
+              label="Personal Information"
+              tooltip="Select which passport fields to request from the user"
+            />
+            <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-[6px] p-[16px] md:p-[20px]">
+              <div className="flex flex-col gap-[12px] sm:flex-row">
+                <div className="flex-1 flex flex-col gap-[12px]">
+                  <CircleCheckbox
+                    checked={!!disclosures.issuing_state}
+                    onChange={() => handleCheckboxChange('issuing_state')}
+                    label="Disclose Issuing State"
+                  />
+                  <CircleCheckbox
+                    checked={!!disclosures.name}
+                    onChange={() => handleCheckboxChange('name')}
+                    label="Disclose Name"
+                  />
+                  <CircleCheckbox
+                    checked={!!disclosures.nationality}
+                    onChange={() => handleCheckboxChange('nationality')}
+                    label="Disclose Nationality"
+                  />
+                  <CircleCheckbox
+                    checked={!!disclosures.date_of_birth}
+                    onChange={() => handleCheckboxChange('date_of_birth')}
+                    label="Disclose Date of Birth"
+                  />
                 </div>
-                <div className="flex items-center gap-[8px] shrink-0">
-                    <a
-                        href="https://github.com/selfxyz/self"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hidden md:flex h-[36px] px-[16px] border border-[#e2e8f0] rounded-[5px] items-center gap-[10px] text-[14px] font-medium text-[#64748b] bg-white hover:bg-slate-50 transition-colors"
-                    >
-                        <span>Star on Github</span>
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-                        </svg>
-                    </a>
-                    <a
-                        href="https://docs.self.xyz"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="h-[36px] px-[12px] md:px-[16px] py-[8px] bg-[#0f172a] text-white rounded-[6px] flex items-center text-[13px] md:text-[14px] font-bold hover:bg-slate-800 transition-colors"
-                    >
-                        Docs
-                    </a>
+                <div className="flex-1 flex flex-col gap-[12px]">
+                  <CircleCheckbox
+                    checked={!!disclosures.passport_number}
+                    onChange={() => handleCheckboxChange('passport_number')}
+                    label="Disclose Passport Number"
+                  />
+                  <CircleCheckbox
+                    checked={!!disclosures.gender}
+                    onChange={() => handleCheckboxChange('gender')}
+                    label="Disclose Gender"
+                  />
+                  <CircleCheckbox
+                    checked={!!disclosures.expiry_date}
+                    onChange={() => handleCheckboxChange('expiry_date')}
+                    label="Disclose Expiry Date"
+                  />
                 </div>
-            </nav>
+              </div>
+            </div>
+          </div>
 
-            {/* Main Content */}
-            <div className="flex-1 flex flex-col lg:flex-row pt-[10px] px-[12px] pb-[40px] md:pr-[20px] md:px-0 rounded-[10px] w-full">
-                {/* Left Column - Config */}
-                <div className="w-full lg:w-[530px] lg:shrink-0 overflow-y-auto flex flex-col gap-[20px] px-[16px] py-[30px] md:gap-[30px] md:px-[40px] md:py-[60px]">
-                    {/* Title */}
-                    <div className="pb-[20px]">
-                        <h1 className="font-advercase text-[28px] font-normal text-black tracking-[1px]">Proof Request Playground</h1>
-                        <p className="text-[14px] font-medium text-[#64748b] mt-[4px] max-w-[380px]">Configure these parameters to dynamically generate a unique QR for testing with the Self Mobile app in Dev Mode.</p>
-                    </div>
-
-                    {/* App Name */}
-                    <div className="flex flex-col gap-[10px]">
-                        <SectionLabel label="Name of Test Application" tooltip="This name appears in the Self app when users scan the QR code" />
-                        <div className="flex items-center h-[36px] px-[16px] border border-[#e2e8f0] rounded-[5px] bg-white shadow-[0px_2px_4px_0px_rgba(0,0,0,0.1)] gap-[10px]">
-                            <input
-                                type="text"
-                                value={appName}
-                                onChange={(e) => setAppName(e.target.value.slice(0, 54))}
-                                className="flex-1 text-[14px] font-medium text-black bg-transparent focus:outline-none placeholder:text-[#94a3b8]"
-                                placeholder="Multipass"
-                                maxLength={54}
-                            />
-                            <span className="text-[12px] font-medium text-[#94a3b8] shrink-0">
-                                54 character limit
-                            </span>
-                        </div>
-                    </div>
-
-                    {/* App Icon */}
-                    <div className="flex flex-col gap-[10px]">
-                        <SectionLabel label="Test Application Icon" tooltip="Icon displayed alongside your app name" />
-                        <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-[6px] flex gap-[12px] items-end overflow-clip pb-[20px] pl-[20px] pt-[50px] relative">
-                            <div className="flex-1 flex flex-col gap-[12px] items-start pr-[30px] max-w-[220px]">
-                                {/* eslint-disable-next-line @next/next/no-img-element */}
-                                <img
-                                    src={appIconUrl}
-                                    alt="App icon"
-                                    width={36}
-                                    height={36}
-                                    className="w-[36px] h-[36px] rounded-[3px] shrink-0 object-cover"
-                                />
-                                <div className="flex flex-col gap-[12px] w-full">
-                                    <button
-                                        onClick={() => {
-                                            setIconUrlInput(appIconUrl);
-                                            setShowIconPopover(prev => !prev);
-                                        }}
-                                        className="h-[36px] px-[16px] text-[14px] font-medium bg-black text-white rounded-[5px] hover:bg-slate-800 transition-colors shrink-0 w-fit"
-                                    >
-                                        Replace icon
-                                    </button>
-                                    <p className="text-[12px] font-medium text-[#94a3b8]">
-                                        400 x 400 pixels. Displayed to users during proof requests.
-                                    </p>
-                                </div>
-                            </div>
-                            <Image
-                                src="/phone.png"
-                                alt="Phone mockup preview"
-                                width={968}
-                                height={784}
-                                className="absolute right-0 bottom-0 h-full w-auto object-contain"
-                            />
-                        </div>
-                    </div>
-
-                    {/* Personal Information */}
-                    <div className="flex flex-col gap-[10px]">
-                        <SectionLabel label="Personal Information" tooltip="Select which passport fields to request from the user" />
-                        <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-[6px] p-[16px] md:p-[20px]">
-                            <div className="flex flex-col gap-[12px] sm:flex-row">
-                                <div className="flex-1 flex flex-col gap-[12px]">
-                                    <CircleCheckbox
-                                        checked={!!disclosures.issuing_state}
-                                        onChange={() => handleCheckboxChange('issuing_state')}
-                                        label="Disclose Issuing State"
-                                    />
-                                    <CircleCheckbox
-                                        checked={!!disclosures.name}
-                                        onChange={() => handleCheckboxChange('name')}
-                                        label="Disclose Name"
-                                    />
-                                    <CircleCheckbox
-                                        checked={!!disclosures.nationality}
-                                        onChange={() => handleCheckboxChange('nationality')}
-                                        label="Disclose Nationality"
-                                    />
-                                    <CircleCheckbox
-                                        checked={!!disclosures.date_of_birth}
-                                        onChange={() => handleCheckboxChange('date_of_birth')}
-                                        label="Disclose Date of Birth"
-                                    />
-                                </div>
-                                <div className="flex-1 flex flex-col gap-[12px]">
-                                    <CircleCheckbox
-                                        checked={!!disclosures.passport_number}
-                                        onChange={() => handleCheckboxChange('passport_number')}
-                                        label="Disclose Passport Number"
-                                    />
-                                    <CircleCheckbox
-                                        checked={!!disclosures.gender}
-                                        onChange={() => handleCheckboxChange('gender')}
-                                        label="Disclose Gender"
-                                    />
-                                    <CircleCheckbox
-                                        checked={!!disclosures.expiry_date}
-                                        onChange={() => handleCheckboxChange('expiry_date')}
-                                        label="Disclose Expiry Date"
-                                    />
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    {/* Verification Rules */}
-                    <div className="flex flex-col gap-[10px]">
-                        <SectionLabel label="Verification Rules" tooltip="Set additional verification requirements beyond disclosure" />
-                        <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-[6px] p-[16px] md:p-[20px] flex flex-col gap-[22px] w-full md:w-fit">
-                            {/* Minimum Age */}
-                            <div className="border-b border-[#cbd5e1] pb-[20px] flex flex-col gap-[10px]">
-                                <span className="text-[14px] font-medium text-black uppercase">Minimum Age</span>
-                                <div className="flex items-center gap-[6px]">
-                                    <button
-                                        onClick={incrementAge}
-                                        className="flex items-center justify-center hover:opacity-80 transition-opacity"
-                                    >
-                                        <Image src="/arrow.png" alt="Increase age" width={31} height={31} className="w-[31px] h-[31px]" />
-                                    </button>
-                                    <div className="h-[55px] px-[16px] flex items-center border border-[#e2e8f0] rounded-[5px] bg-white">
-                                        <span className="text-[24px] font-medium text-black">{disclosures.minimumAge || 0}</span>
-                                    </div>
-                                    <button
-                                        onClick={decrementAge}
-                                        className="flex items-center justify-center hover:opacity-80 transition-opacity"
-                                    >
-                                        <Image src="/arrow.png" alt="Decrease age" width={31} height={31} className="w-[31px] h-[31px] rotate-180" />
-                                    </button>
-                                </div>
-                                <p className="text-[12px] font-medium text-[#94a3b8]">Set to 0 to disable age requirement</p>
-                            </div>
-
-                            {/* OFAC & Excluded Countries */}
-                            <div className="flex flex-col gap-[10px]">
-                                <span className="text-[14px] font-medium text-black uppercase">Enable OFAC Check</span>
-                                <CircleCheckbox
-                                    checked={!!disclosures.ofac}
-                                    onChange={() => handleCheckboxChange('ofac')}
-                                    label="OFAC check enabled"
-                                />
-                                <button
-                                    onClick={() => setShowCountryModal(true)}
-                                    className="h-[36px] px-[16px] text-[14px] font-medium bg-black text-white rounded-[5px] hover:bg-slate-800 transition-colors w-fit"
-                                >
-                                    Configure Excluded Countries
-                                </button>
-                                <p className="text-[12px] font-medium text-[#94a3b8]">
-                                    {disclosures.excludedCountries && disclosures.excludedCountries.length > 0
-                                        ? `${disclosures.excludedCountries.length} countries excluded`
-                                        : 'No countries excluded'}
-                                </p>
-                            </div>
-                        </div>
-                    </div>
+          {/* Verification Rules */}
+          <div className="flex flex-col gap-[10px]">
+            <SectionLabel
+              label="Verification Rules"
+              tooltip="Set additional verification requirements beyond disclosure"
+            />
+            <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-[6px] p-[16px] md:p-[20px] flex flex-col gap-[22px] w-full md:w-fit">
+              {/* Minimum Age */}
+              <div className="border-b border-[#cbd5e1] pb-[20px] flex flex-col gap-[10px]">
+                <span className="text-[14px] font-medium text-black uppercase">
+                  Minimum Age
+                </span>
+                <div className="flex items-center gap-[6px]">
+                  <button
+                    onClick={incrementAge}
+                    className="flex items-center justify-center hover:opacity-80 transition-opacity"
+                  >
+                    <Image
+                      src="/arrow.png"
+                      alt="Increase age"
+                      width={31}
+                      height={31}
+                      className="w-[31px] h-[31px]"
+                    />
+                  </button>
+                  <div className="h-[55px] px-[16px] flex items-center border border-[#e2e8f0] rounded-[5px] bg-white">
+                    <span className="text-[24px] font-medium text-black">
+                      {disclosures.minimumAge || 0}
+                    </span>
+                  </div>
+                  <button
+                    onClick={decrementAge}
+                    className="flex items-center justify-center hover:opacity-80 transition-opacity"
+                  >
+                    <Image
+                      src="/arrow.png"
+                      alt="Decrease age"
+                      width={31}
+                      height={31}
+                      className="w-[31px] h-[31px] rotate-180"
+                    />
+                  </button>
                 </div>
+                <p className="text-[12px] font-medium text-[#94a3b8]">
+                  Set to 0 to disable age requirement
+                </p>
+              </div>
 
-                {/* Right Column - Preview */}
-                <div className="flex-1 bg-[#f8fafc] rounded-[10px] border border-[#e2e8f0] flex flex-col items-center pt-[10px] pb-[20px] min-h-[400px] md:min-h-[600px]">
-                    {/* Preview Tab Bar */}
-                    <div className="flex flex-col gap-[8px] px-[12px] pt-[10px] w-full shrink-0 md:flex-row md:items-center md:justify-end md:gap-[10px] md:px-[20px]">
-                        <div className="flex items-center gap-[12px] h-[36px] overflow-x-auto md:flex-1 md:gap-[20px]">
-                            <span className="text-[12px] md:text-[14px] font-medium text-black uppercase tracking-[0.98px] shrink-0">preview:</span>
-                            {previewTabs.map(tab => (
-                                <button
-                                    key={tab.id}
-                                    onClick={() => tab.enabled && setPreviewTab(tab.id)}
-                                    className={`h-full flex items-center text-[13px] md:text-[14px] font-medium transition-colors whitespace-nowrap shrink-0 ${previewTab === tab.id
-                                        ? 'text-[#2563eb] border-b-2 border-[#2563eb]'
-                                        : tab.enabled
-                                            ? 'text-[#94a3b8] hover:text-slate-700'
-                                            : 'text-[#94a3b8] cursor-not-allowed'
-                                        }`}
-                                    disabled={!tab.enabled}
-                                >
-                                    {tab.label}
-                                </button>
-                            ))}
-                        </div>
-                        {/* <button
+              {/* OFAC & Excluded Countries */}
+              <div className="flex flex-col gap-[10px]">
+                <span className="text-[14px] font-medium text-black uppercase">
+                  Enable OFAC Check
+                </span>
+                <CircleCheckbox
+                  checked={!!disclosures.ofac}
+                  onChange={() => handleCheckboxChange('ofac')}
+                  label="OFAC check enabled"
+                />
+                <button
+                  onClick={() => setShowCountryModal(true)}
+                  className="h-[36px] px-[16px] text-[14px] font-medium bg-black text-white rounded-[5px] hover:bg-slate-800 transition-colors w-fit"
+                >
+                  Configure Excluded Countries
+                </button>
+                <p className="text-[12px] font-medium text-[#94a3b8]">
+                  {disclosures.excludedCountries &&
+                  disclosures.excludedCountries.length > 0
+                    ? `${disclosures.excludedCountries.length} countries excluded`
+                    : 'No countries excluded'}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Right Column - Preview */}
+        <div className="flex-1 bg-[#f8fafc] rounded-[10px] border border-[#e2e8f0] flex flex-col items-center pt-[10px] pb-[20px] min-h-[400px] md:min-h-[600px]">
+          {/* Preview Tab Bar */}
+          <div className="flex flex-col gap-[8px] px-[12px] pt-[10px] w-full shrink-0 md:flex-row md:items-center md:justify-end md:gap-[10px] md:px-[20px]">
+            <div className="flex items-center gap-[12px] h-[36px] overflow-x-auto md:flex-1 md:gap-[20px]">
+              <span className="text-[12px] md:text-[14px] font-medium text-black uppercase tracking-[0.98px] shrink-0">
+                preview:
+              </span>
+              {previewTabs.map(tab => (
+                <button
+                  key={tab.id}
+                  onClick={() => tab.enabled && setPreviewTab(tab.id)}
+                  className={`h-full flex items-center text-[13px] md:text-[14px] font-medium transition-colors whitespace-nowrap shrink-0 ${
+                    previewTab === tab.id
+                      ? 'text-[#2563eb] border-b-2 border-[#2563eb]'
+                      : tab.enabled
+                        ? 'text-[#94a3b8] hover:text-slate-700'
+                        : 'text-[#94a3b8] cursor-not-allowed'
+                  }`}
+                  disabled={!tab.enabled}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+            {/* <button
                             className="hidden md:flex h-[36px] px-[16px] py-[8px] text-[14px] font-bold bg-[#2563eb] text-white rounded-[6px] hover:bg-blue-700 transition-colors shrink-0"
                         >
                             Connect a Wallet
                         </button> */}
-                    </div>
+          </div>
 
-                    {/* QR Code Area */}
-                    <div className="flex-1 flex flex-col items-center justify-center w-full">
-                        {selfApp ? (
-                            <>
-                                <SelfQRcodeWrapper
-                                    key={JSON.stringify(selfApp)}
-                                    variant={previewTab === 'mobile' ? 'mobile' : 'desktop'}
-                                    selfApp={selfApp}
-                                    onSuccess={() => console.log('Verification successful')}
-                                    darkMode={false}
-                                    onError={() => console.error('Error generating QR code')}
-                                />
-                                {previewTab === 'mobile' && universalLink && (
-                                    <div className="mt-[40px] min-w-[300px]">
-                                        <SelfDeepLinkButton href={universalLink} />
-                                    </div>
-                                )}
-                            </>
-                        ) : (
-                            <div className="flex items-center gap-2 text-sm text-[#94a3b8]">
-                                <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-                                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
-                                    <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75" />
-                                </svg>
-                                Loading QR Code...
-                            </div>
-                        )}
-                    </div>
+          {/* QR Code Area */}
+          <div className="flex-1 flex flex-col items-center justify-center w-full">
+            {selfApp ? (
+              <>
+                <SelfQRcodeWrapper
+                  key={JSON.stringify(selfApp)}
+                  variant={previewTab === 'mobile' ? 'mobile' : 'desktop'}
+                  selfApp={selfApp}
+                  onSuccess={() => console.log('Verification successful')}
+                  darkMode={false}
+                  onError={() => console.error('Error generating QR code')}
+                />
+                {previewTab === 'mobile' && universalLink && (
+                  <div className="mt-[40px] min-w-[300px]">
+                    <SelfDeepLinkButton href={universalLink} />
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="flex items-center gap-2 text-sm text-[#94a3b8]">
+                <svg
+                  className="animate-spin h-4 w-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                >
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    className="opacity-25"
+                  />
+                  <path
+                    d="M4 12a8 8 0 018-8"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    className="opacity-75"
+                  />
+                </svg>
+                Loading QR Code...
+              </div>
+            )}
+          </div>
 
-                    {/* Preview Footer */}
-                    <div className="flex flex-col gap-[10px] items-center shrink-0">
-                        <span className="text-[12px] text-[#94a3b8] font-ibm-mono font-medium text-center">
-                            User ID: {userId.substring(0, 8)}...
-                        </span>
-                        <div className="bg-[#94a3b8] px-[6px] py-[4px] rounded-[4px]">
-                            <span className="text-[12px] font-medium text-white text-center">
-                                TEST INSTRUCTIONS: Scan QR code to test configuration
-                            </span>
-                        </div>
-                    </div>
-                </div>
+          {/* Preview Footer */}
+          <div className="flex flex-col gap-[10px] items-center shrink-0">
+            <span className="text-[12px] text-[#94a3b8] font-ibm-mono font-medium text-center">
+              User ID: {userId.substring(0, 8)}...
+            </span>
+            <div className="bg-[#94a3b8] px-[6px] py-[4px] rounded-[4px]">
+              <span className="text-[12px] font-medium text-white text-center">
+                TEST INSTRUCTIONS: Scan QR code to test configuration
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Icon URL Popover */}
+      {showIconPopover && (
+        <div
+          className="fixed inset-0 z-50"
+          onClick={() => setShowIconPopover(false)}
+        >
+          <div
+            className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white border border-[#e2e8f0] rounded-[6px] shadow-lg p-[16px] flex flex-col gap-[12px] w-[360px]"
+            onClick={e => e.stopPropagation()}
+          >
+            <label className="text-[13px] font-medium text-black">
+              Icon URL (PNG, 400x400)
+            </label>
+            <input
+              type="url"
+              value={iconUrlInput}
+              onChange={e => setIconUrlInput(e.target.value)}
+              placeholder="https://example.com/icon.png"
+              className="h-[36px] px-[12px] border border-[#e2e8f0] rounded-[5px] text-[13px] text-black bg-white focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
+              autoFocus
+              onKeyDown={e => {
+                if (e.key === 'Enter' && iconUrlInput.trim()) {
+                  setAppIconUrl(iconUrlInput.trim());
+                  setShowIconPopover(false);
+                }
+                if (e.key === 'Escape') setShowIconPopover(false);
+              }}
+            />
+            <div className="flex gap-[8px] justify-end">
+              <button
+                onClick={() => setShowIconPopover(false)}
+                className="h-[32px] px-[12px] text-[13px] font-medium border border-[#e2e8f0] rounded-[5px] text-[#64748b] hover:bg-slate-50 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  if (iconUrlInput.trim()) {
+                    setAppIconUrl(iconUrlInput.trim());
+                    setShowIconPopover(false);
+                  }
+                }}
+                className="h-[32px] px-[12px] text-[13px] font-medium bg-black text-white rounded-[5px] hover:bg-slate-800 transition-colors"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Country Selection Modal */}
+      {showCountryModal && (
+        <div className="fixed inset-0 bg-slate-900/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-[10px] shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col mx-4">
+            <div className="px-6 py-4 border-b border-slate-200 flex items-center justify-between shrink-0">
+              <h3 className="text-lg font-semibold text-slate-900">
+                Exclude Countries
+              </h3>
+              <button
+                onClick={() => setShowCountryModal(false)}
+                className="w-8 h-8 flex items-center justify-center rounded-[5px] text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                  <path
+                    d="M4 4L12 12M12 4L4 12"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
             </div>
 
-            {/* Icon URL Popover */}
-            {showIconPopover && (
-                <div className="fixed inset-0 z-50" onClick={() => setShowIconPopover(false)}>
+            {countrySelectionError && (
+              <div className="mx-6 mt-4 p-2.5 bg-red-50 text-red-600 text-sm rounded-[5px]">
+                {countrySelectionError}
+              </div>
+            )}
+
+            <div className="px-6 pt-4">
+              <input
+                type="text"
+                placeholder="Search countries..."
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                className="w-full h-10 px-3 border border-slate-200 rounded-[5px] text-sm text-slate-900 bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
+              />
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-6 py-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-1">
+                {filteredCountries.map(([code, country]) => (
+                  <label
+                    key={code}
+                    className="flex items-center gap-2 px-2 py-1.5 rounded-[5px] hover:bg-slate-50 cursor-pointer transition-colors"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedCountries.includes(
+                        code as Country3LetterCode,
+                      )}
+                      onChange={() =>
+                        handleCountryToggle(code as Country3LetterCode)
+                      }
+                      className="sr-only"
+                    />
                     <div
-                        className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white border border-[#e2e8f0] rounded-[6px] shadow-lg p-[16px] flex flex-col gap-[12px] w-[360px]"
-                        onClick={(e) => e.stopPropagation()}
+                      className={`w-4 h-4 rounded-full flex items-center justify-center shrink-0 transition-colors ${
+                        selectedCountries.includes(code as Country3LetterCode)
+                          ? 'bg-blue-600'
+                          : 'border-2 border-slate-300'
+                      }`}
                     >
-                        <label className="text-[13px] font-medium text-black">Icon URL (PNG, 400x400)</label>
-                        <input
-                            type="url"
-                            value={iconUrlInput}
-                            onChange={(e) => setIconUrlInput(e.target.value)}
-                            placeholder="https://example.com/icon.png"
-                            className="h-[36px] px-[12px] border border-[#e2e8f0] rounded-[5px] text-[13px] text-black bg-white focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
-                            autoFocus
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter' && iconUrlInput.trim()) {
-                                    setAppIconUrl(iconUrlInput.trim());
-                                    setShowIconPopover(false);
-                                }
-                                if (e.key === 'Escape') setShowIconPopover(false);
-                            }}
-                        />
-                        <div className="flex gap-[8px] justify-end">
-                            <button
-                                onClick={() => setShowIconPopover(false)}
-                                className="h-[32px] px-[12px] text-[13px] font-medium border border-[#e2e8f0] rounded-[5px] text-[#64748b] hover:bg-slate-50 transition-colors"
-                            >
-                                Cancel
-                            </button>
-                            <button
-                                onClick={() => {
-                                    if (iconUrlInput.trim()) {
-                                        setAppIconUrl(iconUrlInput.trim());
-                                        setShowIconPopover(false);
-                                    }
-                                }}
-                                className="h-[32px] px-[12px] text-[13px] font-medium bg-black text-white rounded-[5px] hover:bg-slate-800 transition-colors"
-                            >
-                                Apply
-                            </button>
-                        </div>
+                      {selectedCountries.includes(
+                        code as Country3LetterCode,
+                      ) && (
+                        <svg
+                          width="8"
+                          height="6"
+                          viewBox="0 0 10 8"
+                          fill="none"
+                        >
+                          <path
+                            d="M1 4L3.5 6.5L9 1"
+                            stroke="white"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      )}
                     </div>
-                </div>
-            )}
+                    <span className="text-sm text-slate-700">{country}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
 
-            {/* Country Selection Modal */}
-            {showCountryModal && (
-                <div className="fixed inset-0 bg-slate-900/50 flex items-center justify-center z-50">
-                    <div className="bg-white rounded-[10px] shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col mx-4">
-                        <div className="px-6 py-4 border-b border-slate-200 flex items-center justify-between shrink-0">
-                            <h3 className="text-lg font-semibold text-slate-900">Exclude Countries</h3>
-                            <button
-                                onClick={() => setShowCountryModal(false)}
-                                className="w-8 h-8 flex items-center justify-center rounded-[5px] text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
-                            >
-                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                                    <path d="M4 4L12 12M12 4L4 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                                </svg>
-                            </button>
-                        </div>
-
-                        {countrySelectionError && (
-                            <div className="mx-6 mt-4 p-2.5 bg-red-50 text-red-600 text-sm rounded-[5px]">
-                                {countrySelectionError}
-                            </div>
-                        )}
-
-                        <div className="px-6 pt-4">
-                            <input
-                                type="text"
-                                placeholder="Search countries..."
-                                value={searchQuery}
-                                onChange={(e) => setSearchQuery(e.target.value)}
-                                className="w-full h-10 px-3 border border-slate-200 rounded-[5px] text-sm text-slate-900 bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
-                            />
-                        </div>
-
-                        <div className="flex-1 overflow-y-auto px-6 py-4">
-                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-1">
-                                {filteredCountries.map(([code, country]) => (
-                                    <label
-                                        key={code}
-                                        className="flex items-center gap-2 px-2 py-1.5 rounded-[5px] hover:bg-slate-50 cursor-pointer transition-colors"
-                                    >
-                                        <input
-                                            type="checkbox"
-                                            checked={selectedCountries.includes(code as Country3LetterCode)}
-                                            onChange={() => handleCountryToggle(code as Country3LetterCode)}
-                                            className="sr-only"
-                                        />
-                                        <div
-                                            className={`w-4 h-4 rounded-full flex items-center justify-center shrink-0 transition-colors ${selectedCountries.includes(code as Country3LetterCode)
-                                                ? 'bg-blue-600'
-                                                : 'border-2 border-slate-300'
-                                                }`}
-                                        >
-                                            {selectedCountries.includes(code as Country3LetterCode) && (
-                                                <svg width="8" height="6" viewBox="0 0 10 8" fill="none">
-                                                    <path d="M1 4L3.5 6.5L9 1" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                                                </svg>
-                                            )}
-                                        </div>
-                                        <span className="text-sm text-slate-700">{country}</span>
-                                    </label>
-                                ))}
-                            </div>
-                        </div>
-
-                        <div className="px-6 py-4 border-t border-slate-200 flex items-center justify-between shrink-0">
-                            <span className="text-xs text-slate-400">
-                                {selectedCountries.length} selected (max 40)
-                            </span>
-                            <div className="flex items-center gap-3">
-                                <button
-                                    onClick={() => setShowCountryModal(false)}
-                                    className="h-9 px-4 text-sm border border-slate-200 rounded-[5px] text-slate-600 hover:bg-slate-50 transition-colors"
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    onClick={saveCountrySelection}
-                                    className="h-9 px-4 text-sm font-medium bg-blue-600 text-white rounded-[5px] hover:bg-blue-700 transition-colors"
-                                >
-                                    Apply
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            )}
+            <div className="px-6 py-4 border-t border-slate-200 flex items-center justify-between shrink-0">
+              <span className="text-xs text-slate-400">
+                {selectedCountries.length} selected (max 40)
+              </span>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => setShowCountryModal(false)}
+                  className="h-9 px-4 text-sm border border-slate-200 rounded-[5px] text-slate-600 hover:bg-slate-50 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={saveCountrySelection}
+                  className="h-9 px-4 text-sm font-medium bg-blue-600 text-white rounded-[5px] hover:bg-blue-700 transition-colors"
+                >
+                  Apply
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
-    );
+      )}
+    </div>
+  );
 }
 
 export default Playground;

--- a/app/components/Playground.tsx
+++ b/app/components/Playground.tsx
@@ -30,6 +30,22 @@ const SelfDeepLinkButton = dynamic(
   { ssr: false },
 );
 
+const DEFAULT_ICON_URL =
+  'https://image2url.com/r2/default/images/1772123009674-14365df5-cc03-433d-9c21-814d43ad2fb8.png';
+
+// Only allow http(s) URLs into <img src> / QR payload to block javascript: and data: vectors (CodeQL).
+function sanitizeIconUrl(candidate: string): string {
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.toString();
+    }
+  } catch {
+    // fall through
+  }
+  return DEFAULT_ICON_URL;
+}
+
 function Playground() {
   const [userId, setUserId] = useState<string | null>(null);
   const [savingOptions, setSavingOptions] = useState(false);
@@ -37,9 +53,7 @@ function Playground() {
   const [token, setToken] = useState<string | null>(null);
   const [isFetchingToken, setIsFetchingToken] = useState(false);
   const [appName, setAppName] = useState('Self Playground');
-  const [appIconUrl, setAppIconUrl] = useState(
-    'https://image2url.com/r2/default/images/1772123009674-14365df5-cc03-433d-9c21-814d43ad2fb8.png',
-  );
+  const [appIconUrl, setAppIconUrl] = useState(DEFAULT_ICON_URL);
   const [previewTab, setPreviewTab] = useState<
     'desktop' | 'mobile' | 'alternates' | 'code'
   >('desktop');
@@ -681,7 +695,7 @@ function Playground() {
               autoFocus
               onKeyDown={e => {
                 if (e.key === 'Enter' && iconUrlInput.trim()) {
-                  setAppIconUrl(iconUrlInput.trim());
+                  setAppIconUrl(sanitizeIconUrl(iconUrlInput.trim()));
                   setShowIconPopover(false);
                 }
                 if (e.key === 'Escape') setShowIconPopover(false);
@@ -697,7 +711,7 @@ function Playground() {
               <button
                 onClick={() => {
                   if (iconUrlInput.trim()) {
-                    setAppIconUrl(iconUrlInput.trim());
+                    setAppIconUrl(sanitizeIconUrl(iconUrlInput.trim()));
                     setShowIconPopover(false);
                   }
                 }}

--- a/app/components/SectionLabel.tsx
+++ b/app/components/SectionLabel.tsx
@@ -3,38 +3,54 @@
 import React, { useState } from 'react';
 
 interface SectionLabelProps {
-    label: string;
-    tooltip?: string;
+  label: string;
+  tooltip?: string;
 }
 
 export default function SectionLabel({ label, tooltip }: SectionLabelProps) {
-    const [showTooltip, setShowTooltip] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(false);
 
-    return (
-        <div className="flex items-center gap-[12px]">
-            <span className="text-[14px] font-medium uppercase text-[#64748b]">
-                {label}
-            </span>
-            {tooltip && (
-                <div className="relative">
-                    <div
-                        onMouseEnter={() => setShowTooltip(true)}
-                        onMouseLeave={() => setShowTooltip(false)}
-                        className="w-[17px] h-[20px] flex items-center justify-center cursor-help text-[#94a3b8]"
-                    >
-                        <svg width="17" height="20" viewBox="0 0 17 20" fill="none">
-                            <circle cx="8.5" cy="10" r="7.5" stroke="#94A3B8" strokeWidth="1.5" />
-                            <text x="8.5" y="14.5" textAnchor="middle" fill="#94A3B8" fontSize="12" fontWeight="600" fontFamily="system-ui">i</text>
-                        </svg>
-                    </div>
-                    {showTooltip && (
-                        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 bg-slate-900 text-white text-xs rounded-md whitespace-nowrap z-10">
-                            {tooltip}
-                            <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-slate-900" />
-                        </div>
-                    )}
-                </div>
-            )}
+  return (
+    <div className="flex items-center gap-[12px]">
+      <span className="text-[14px] font-medium uppercase text-[#64748b]">
+        {label}
+      </span>
+      {tooltip && (
+        <div className="relative">
+          <div
+            onMouseEnter={() => setShowTooltip(true)}
+            onMouseLeave={() => setShowTooltip(false)}
+            className="w-[17px] h-[20px] flex items-center justify-center cursor-help text-[#94a3b8]"
+          >
+            <svg width="17" height="20" viewBox="0 0 17 20" fill="none">
+              <circle
+                cx="8.5"
+                cy="10"
+                r="7.5"
+                stroke="#94A3B8"
+                strokeWidth="1.5"
+              />
+              <text
+                x="8.5"
+                y="14.5"
+                textAnchor="middle"
+                fill="#94A3B8"
+                fontSize="12"
+                fontWeight="600"
+                fontFamily="system-ui"
+              >
+                i
+              </text>
+            </svg>
+          </div>
+          {showTooltip && (
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 bg-slate-900 text-white text-xs rounded-md whitespace-nowrap z-10">
+              {tooltip}
+              <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-slate-900" />
+            </div>
+          )}
         </div>
-    );
+      )}
+    </div>
+  );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,8 +4,9 @@
 
 @font-face {
   font-family: 'Advercase';
-  src: url('/fonts/advercase-regular.woff2') format('woff2'),
-       url('/fonts/advercase-regular.woff') format('woff');
+  src:
+    url('/fonts/advercase-regular.woff2') format('woff2'),
+    url('/fonts/advercase-regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -13,8 +14,9 @@
 
 @font-face {
   font-family: 'Advercase';
-  src: url('/fonts/advercase-bold.woff2') format('woff2'),
-       url('/fonts/advercase-bold.woff') format('woff');
+  src:
+    url('/fonts/advercase-bold.woff2') format('woff2'),
+    url('/fonts/advercase-bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
   font-display: swap;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,26 +1,27 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono, IBM_Plex_Mono } from "next/font/google";
-import "./globals.css";
+import type { Metadata } from 'next';
+import { Geist, Geist_Mono, IBM_Plex_Mono } from 'next/font/google';
+
+import './globals.css';
 
 const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+  variable: '--font-geist-sans',
+  subsets: ['latin'],
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  variable: '--font-geist-mono',
+  subsets: ['latin'],
 });
 
 const ibmPlexMono = IBM_Plex_Mono({
-  variable: "--font-ibm-plex-mono",
-  subsets: ["latin"],
-  weight: ["400", "500"],
+  variable: '--font-ibm-plex-mono',
+  subsets: ['latin'],
+  weight: ['400', '500'],
 });
 
 export const metadata: Metadata = {
-  title: "Self Playground",
-  description: "Self Playground",
+  title: 'Self Playground',
+  description: 'Self Playground',
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import React from 'react';
 import dynamic from 'next/dynamic';
+import React from 'react';
 
-const Playground = dynamic(() => import("./components/Playground"), {
-    ssr: false,
-    loading: () => (
-      <div className="h-screen w-full flex items-center justify-center">
-        Loading application...
-      </div>
-    ),
+const Playground = dynamic(() => import('./components/Playground'), {
+  ssr: false,
+  loading: () => (
+    <div className="h-screen w-full flex items-center justify-center">
+      Loading application...
+    </div>
+  ),
 });
 
 export default function Page() {
-    return <Playground />;
+  return <Playground />;
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,10 @@
+import prettierConfig from 'eslint-config-prettier';
+import importPlugin from 'eslint-plugin-import';
+import prettierPlugin from 'eslint-plugin-prettier';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { FlatCompat } from '@eslint/eslintrc';
-import simpleImportSort from 'eslint-plugin-simple-import-sort';
-import importPlugin from 'eslint-plugin-import';
-import prettierPlugin from 'eslint-plugin-prettier';
-import prettierConfig from 'eslint-config-prettier';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -24,6 +24,7 @@ const eslintConfig = [
       'dist/',
       'public/',
       '*.js.map',
+      'next-env.d.ts',
     ],
   },
   {
@@ -63,10 +64,7 @@ const eslintConfig = [
       'import/no-unresolved': 'off',
 
       // Formatting / whitespace
-      'no-multiple-empty-lines': [
-        'error',
-        { max: 1, maxEOF: 0, maxBOF: 1 },
-      ],
+      'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0, maxBOF: 1 }],
       'prettier/prettier': ['warn', {}, { usePrettierrc: true }],
 
       // TypeScript

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,10 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import importPlugin from 'eslint-plugin-import';
+import prettierPlugin from 'eslint-plugin-prettier';
+import prettierConfig from 'eslint-config-prettier';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,13 +14,88 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
+    ignores: [
+      'node_modules/',
+      '.next/',
+      'out/',
+      'build/',
+      'dist/',
+      'public/',
+      '*.js.map',
+    ],
+  },
+  {
+    plugins: {
+      'simple-import-sort': simpleImportSort,
+      import: importPlugin,
+      prettier: prettierPlugin,
+    },
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "off"
-    }
-  }
+      ...prettierConfig.rules,
+
+      // Import/export ordering (groups mirror selfxyz/self)
+      'import/order': 'off',
+      'no-duplicate-imports': 'off',
+      'simple-import-sort/imports': [
+        'error',
+        {
+          groups: [
+            // Node.js built-ins
+            ['^node:'],
+            ['^node:.*/'],
+            // External packages (including @-prefixed external packages)
+            ['^[a-zA-Z]', '^@(?!selfxyz|/)'],
+            // Internal workspace packages
+            ['^@selfxyz/'],
+            // Internal alias imports
+            ['^@/'],
+            // Internal relative imports
+            ['^[./]'],
+          ],
+        },
+      ],
+      'simple-import-sort/exports': 'error',
+      'import/first': 'error',
+      'import/newline-after-import': 'error',
+      'import/no-duplicates': 'error',
+      'import/no-unresolved': 'off',
+
+      // Formatting / whitespace
+      'no-multiple-empty-lines': [
+        'error',
+        { max: 1, maxEOF: 0, maxBOF: 1 },
+      ],
+      'prettier/prettier': ['warn', {}, { usePrettierrc: true }],
+
+      // TypeScript
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          disallowTypeAnnotations: false,
+        },
+      ],
+      '@typescript-eslint/ban-ts-comment': 'off',
+
+      // Prevent export * (bad for tree shaking)
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'ExportAllDeclaration',
+          message:
+            'export * is forbidden. Use selective exports for better tree shaking.',
+        },
+      ],
+
+      // General
+      'no-console': 'off',
+      'prefer-const': 'warn',
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/lib/configStore.ts
+++ b/lib/configStore.ts
@@ -1,5 +1,6 @@
-import { IConfigStorage, VerificationConfig } from "@selfxyz/core";
-import { Redis } from "@upstash/redis";
+import { Redis } from '@upstash/redis';
+
+import type { IConfigStorage, VerificationConfig } from '@selfxyz/core';
 
 const TTL_SECONDS = 1800;
 
@@ -61,15 +62,15 @@ export function createConfigStore(): IConfigStorage {
   if (url && token) {
     return new KVConfigStore(url, token);
   }
-  if (process.env.NODE_ENV === "production") {
+  if (process.env.NODE_ENV === 'production') {
     throw new Error(
-      "KV_REST_API_URL and KV_REST_API_TOKEN must be set in production"
+      'KV_REST_API_URL and KV_REST_API_TOKEN must be set in production',
     );
   }
   if (!warnedAboutFallback) {
     warnedAboutFallback = true;
     console.warn(
-      "[playground] KV_REST_API_URL/TOKEN not set — using in-memory config store (dev only)"
+      '[playground] KV_REST_API_URL/TOKEN not set — using in-memory config store (dev only)',
     );
   }
   return new InMemoryConfigStore();

--- a/lib/configStore.ts
+++ b/lib/configStore.ts
@@ -1,0 +1,76 @@
+import { IConfigStorage, VerificationConfig } from "@selfxyz/core";
+import { Redis } from "@upstash/redis";
+
+const TTL_SECONDS = 1800;
+
+export class KVConfigStore implements IConfigStorage {
+  private redis: Redis;
+
+  constructor(url: string, token: string) {
+    this.redis = new Redis({ url, token });
+  }
+
+  async getActionId(userIdentifier: string): Promise<string> {
+    return userIdentifier;
+  }
+
+  async setConfig(id: string, config: VerificationConfig): Promise<boolean> {
+    await this.redis.setex(id, TTL_SECONDS, JSON.stringify(config));
+    return true;
+  }
+
+  async getConfig(id: string): Promise<VerificationConfig> {
+    return (await this.redis.get(id)) as VerificationConfig;
+  }
+}
+
+type MemoryEntry = { config: VerificationConfig; expiresAt: number };
+const memoryStore: Map<string, MemoryEntry> =
+  (globalThis as any).__selfPlaygroundMemoryStore ??
+  ((globalThis as any).__selfPlaygroundMemoryStore = new Map());
+
+export class InMemoryConfigStore implements IConfigStorage {
+  async getActionId(userIdentifier: string): Promise<string> {
+    return userIdentifier;
+  }
+
+  async setConfig(id: string, config: VerificationConfig): Promise<boolean> {
+    memoryStore.set(id, {
+      config,
+      expiresAt: Date.now() + TTL_SECONDS * 1000,
+    });
+    return true;
+  }
+
+  async getConfig(id: string): Promise<VerificationConfig> {
+    const entry = memoryStore.get(id);
+    if (!entry) return undefined as unknown as VerificationConfig;
+    if (entry.expiresAt < Date.now()) {
+      memoryStore.delete(id);
+      return undefined as unknown as VerificationConfig;
+    }
+    return entry.config;
+  }
+}
+
+let warnedAboutFallback = false;
+
+export function createConfigStore(): IConfigStorage {
+  const url = process.env.KV_REST_API_URL;
+  const token = process.env.KV_REST_API_TOKEN;
+  if (url && token) {
+    return new KVConfigStore(url, token);
+  }
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "KV_REST_API_URL and KV_REST_API_TOKEN must be set in production"
+    );
+  }
+  if (!warnedAboutFallback) {
+    warnedAboutFallback = true;
+    console.warn(
+      "[playground] KV_REST_API_URL/TOKEN not set — using in-memory config store (dev only)"
+    );
+  }
+  return new InMemoryConfigStore();
+}

--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
   webpack: (config, { isServer }) => {
     // Fix for packages that use 'document' in server context
     if (isServer) {
-      config.externals = [...(config.externals || []), "@selfxyz/qrcode"];
+      config.externals = [...(config.externals || []), '@selfxyz/qrcode'];
     }
 
     return config;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "dev": "rm -rf .next && next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint . --cache --cache-location .eslintcache",
+    "lint:fix": "eslint --fix . --cache --cache-location .eslintcache",
+    "fmt": "prettier --check --cache .",
+    "fmt:fix": "prettier --write --cache .",
+    "nice": "yarn fmt:fix && yarn lint:fix",
+    "format": "yarn nice"
   },
   "dependencies": {
     "@selfxyz/core": "^1.2.0-beta.1",
@@ -25,6 +30,11 @@
     "@types/react-dom": "^19.0.4",
     "eslint": "^9",
     "eslint-config-next": "15.1.7",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
+    "prettier": "^3.8.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.7.3"

--- a/package.json
+++ b/package.json
@@ -4,15 +4,19 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "rm -rf .next && next dev",
     "build": "next build",
-    "start": "next start",
-    "lint": "eslint . --cache --cache-location .eslintcache",
-    "lint:fix": "eslint --fix . --cache --cache-location .eslintcache",
+    "dev": "rm -rf .next && next dev",
     "fmt": "prettier --check --cache .",
     "fmt:fix": "prettier --write --cache .",
+    "format": "yarn nice",
+    "lint": "eslint . --cache --cache-location .eslintcache",
+    "lint:fix": "eslint --fix . --cache --cache-location .eslintcache",
     "nice": "yarn fmt:fix && yarn lint:fix",
-    "format": "yarn nice"
+    "start": "next start",
+    "types": "tsc --noEmit"
+  },
+  "resolutions": {
+    "@selfxyz/sdk-common": "link:../self/sdk/sdk-common"
   },
   "dependencies": {
     "@selfxyz/core": "^1.2.0-beta.1",
@@ -34,16 +38,13 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "prettier": "^3.8.1",
     "postcss": "^8",
+    "prettier": "^3.8.1",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.7.3"
   },
-  "resolutions": {
-    "@selfxyz/sdk-common": "link:../self/sdk/sdk-common"
-  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "engines": {
     "node": "22.x"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/pages/api/deferredLinking.ts
+++ b/pages/api/deferredLinking.ts
@@ -1,30 +1,33 @@
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(
-    req: NextApiRequest,
-    res: NextApiResponse
+  req: NextApiRequest,
+  res: NextApiResponse,
 ) {
-    if (req.method === "POST") {
-        try {
-            const payload = req.body;
+  if (req.method === 'POST') {
+    try {
+      const payload = req.body;
 
-            const response = await fetch("https://api.staging.self.xyz/post-deferred-linking-token", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify(payload),
-            });
+      const response = await fetch(
+        'https://api.staging.self.xyz/post-deferred-linking-token',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        },
+      );
 
-            if (!response.ok) {
-                throw new Error(`API error: ${response.status}`);
-            }
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`);
+      }
 
-            const data = await response.json();
-            res.status(200).json(data);
-        } catch (error) {
-            console.error("Proxy error:", error);
-            res.status(500).json({ error: "Failed to fetch token" });
-        }
+      const data = await response.json();
+      res.status(200).json(data);
+    } catch (error) {
+      console.error('Proxy error:', error);
+      res.status(500).json({ error: 'Failed to fetch token' });
     }
+  }
 }

--- a/pages/api/saveOptions.ts
+++ b/pages/api/saveOptions.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { KVConfigStore } from "./verify";
+import { createConfigStore } from "@/lib/configStore";
 
 export default async function handler(
   req: NextApiRequest,
@@ -22,10 +22,7 @@ export default async function handler(
 
     console.log("Saving options for user:", userId, options);
     // Store the options in Vercel KV with a 30-minute expiration
-    const configStore = new KVConfigStore(
-      process.env.KV_REST_API_URL!,
-      process.env.KV_REST_API_TOKEN!
-    );
+    const configStore = createConfigStore();
     await configStore.setConfig(userId, options);
 
     return res.status(200).json({ message: "Options saved successfully" });

--- a/pages/api/saveOptions.ts
+++ b/pages/api/saveOptions.ts
@@ -1,36 +1,37 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import { createConfigStore } from "@/lib/configStore";
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { createConfigStore } from '@/lib/configStore';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
 ) {
-  if (req.method !== "POST") {
-    return res.status(405).json({ message: "Method not allowed" });
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
   }
 
   try {
     const { userId, options } = req.body;
 
     if (!userId) {
-      return res.status(400).json({ message: "User ID is required" });
+      return res.status(400).json({ message: 'User ID is required' });
     }
 
     if (!options) {
-      return res.status(400).json({ message: "Options are required" });
+      return res.status(400).json({ message: 'Options are required' });
     }
 
-    console.log("Saving options for user:", userId, options);
+    console.log('Saving options for user:', userId, options);
     // Store the options in Vercel KV with a 30-minute expiration
     const configStore = createConfigStore();
     await configStore.setConfig(userId, options);
 
-    return res.status(200).json({ message: "Options saved successfully" });
+    return res.status(200).json({ message: 'Options saved successfully' });
   } catch (error) {
-    console.error("Error saving options:", error);
+    console.error('Error saving options:', error);
     return res.status(500).json({
-      message: "Internal server error",
-      error: error instanceof Error ? error.message : "Unknown error",
+      message: 'Internal server error',
+      error: error instanceof Error ? error.message : 'Unknown error',
     });
   }
 }

--- a/pages/api/verify.ts
+++ b/pages/api/verify.ts
@@ -1,132 +1,130 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import { SelfAppDisclosureConfig } from "@selfxyz/common";
-import {
-  countryCodes,
-  SelfBackendVerifier,
-  AllIds,
-} from "@selfxyz/core";
-import { createConfigStore } from "@/lib/configStore";
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import type { SelfAppDisclosureConfig } from '@selfxyz/common';
+import { AllIds, countryCodes, SelfBackendVerifier } from '@selfxyz/core';
+
+import { createConfigStore } from '@/lib/configStore';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
 ) {
-  if (req.method === "POST") {
+  if (req.method === 'POST') {
     try {
       const { attestationId, proof, publicSignals, userContextData } = req.body;
 
       if (!proof || !publicSignals || !attestationId || !userContextData) {
         return res.status(400).json({
           message:
-            "Proof, publicSignals, attestationId and userContextData are required",
+            'Proof, publicSignals, attestationId and userContextData are required',
         });
       }
 
       const configStore = createConfigStore();
 
       const selfBackendVerifier = new SelfBackendVerifier(
-        "self-playground",
-        "https://playground.self.xyz/api/verify",
+        'self-playground',
+        'https://playground.self.xyz/api/verify',
         false,
         AllIds,
         configStore,
-        "uuid"
+        'uuid',
       );
 
       const result = await selfBackendVerifier.verify(
         attestationId,
         proof,
         publicSignals,
-        userContextData
+        userContextData,
       );
 
       if (!result.isValidDetails.isMinimumAgeValid) {
         return res.status(200).json({
-          status: "error",
+          status: 'error',
           result: false,
-          reason: "Minimum age verification failed",
+          reason: 'Minimum age verification failed',
           details: result.isValidDetails,
         });
       }
 
       if (result.isValidDetails.isOfacValid) {
         return res.status(200).json({
-          status: "error",
+          status: 'error',
           result: false,
-          reason: "OFAC verification failed",
+          reason: 'OFAC verification failed',
           details: result.isValidDetails,
         });
       }
 
       if (!result.isValidDetails.isValid) {
         return res.status(200).json({
-          status: "error",
+          status: 'error',
           result: false,
-          reason: "Verification failed",
+          reason: 'Verification failed',
           details: result.isValidDetails,
         });
       }
 
       const saveOptions = (await configStore.getConfig(
-        result.userData.userIdentifier
+        result.userData.userIdentifier,
       )) as unknown as SelfAppDisclosureConfig;
 
       if (result.isValidDetails.isValid) {
         const filteredSubject = { ...result.discloseOutput };
 
         if (!saveOptions.issuing_state && filteredSubject) {
-          filteredSubject.issuingState = "Not disclosed";
+          filteredSubject.issuingState = 'Not disclosed';
         }
         if (!saveOptions.name && filteredSubject) {
-          filteredSubject.name = "Not disclosed";
+          filteredSubject.name = 'Not disclosed';
         }
         if (!saveOptions.nationality && filteredSubject) {
-          filteredSubject.nationality = "Not disclosed";
+          filteredSubject.nationality = 'Not disclosed';
         }
         if (!saveOptions.date_of_birth && filteredSubject) {
-          filteredSubject.dateOfBirth = "Not disclosed";
+          filteredSubject.dateOfBirth = 'Not disclosed';
         }
         if (!saveOptions.passport_number && filteredSubject) {
-          filteredSubject.idNumber = "Not disclosed";
+          filteredSubject.idNumber = 'Not disclosed';
         }
         if (!saveOptions.gender && filteredSubject) {
-          filteredSubject.gender = "Not disclosed";
+          filteredSubject.gender = 'Not disclosed';
         }
         if (!saveOptions.expiry_date && filteredSubject) {
-          filteredSubject.expiryDate = "Not disclosed";
+          filteredSubject.expiryDate = 'Not disclosed';
         }
 
         res.status(200).json({
-          status: "success",
+          status: 'success',
           result: result.isValidDetails.isValid,
           credentialSubject: filteredSubject,
           verificationOptions: {
             minimumAge: saveOptions.minimumAge,
             ofac: saveOptions.ofac,
             excludedCountries: saveOptions.excludedCountries?.map(
-              (countryName) => {
+              countryName => {
                 const entry = Object.entries(countryCodes).find(
-                  ([_, name]) => name === countryName
+                  ([_, name]) => name === countryName,
                 );
                 return entry ? entry[0] : countryName;
-              }
+              },
             ),
           },
         });
       } else {
         res.status(200).json({
-          status: "error",
+          status: 'error',
           result: result.isValidDetails.isValid,
-          reason: "Proof verification failed",
+          reason: 'Proof verification failed',
           details: result,
         });
       }
     } catch (error) {
-      console.error("Error verifying proof:", error);
+      console.error('Error verifying proof:', error);
       return res.status(200).json({
-        status: "error",
+        status: 'error',
         result: false,
-        reason: error instanceof Error ? error.message : "Unknown error",
+        reason: error instanceof Error ? error.message : 'Unknown error',
       });
     }
   }

--- a/pages/api/verify.ts
+++ b/pages/api/verify.ts
@@ -1,38 +1,11 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { SelfAppDisclosureConfig } from "@selfxyz/common";
 import {
-  IConfigStorage,
-  VerificationConfig,
   countryCodes,
   SelfBackendVerifier,
   AllIds,
 } from "@selfxyz/core";
-import { Redis } from "@upstash/redis";
-
-export class KVConfigStore implements IConfigStorage {
-  private redis: Redis;
-
-  constructor(url: string, token: string) {
-    this.redis = new Redis({
-      url: url,
-      token: token,
-    });
-  }
-
-  async getActionId(userIdentifier: string, data: string): Promise<string> {
-    return userIdentifier;
-  }
-
-  async setConfig(id: string, config: VerificationConfig): Promise<boolean> {
-    await this.redis.setex(id, 1800, JSON.stringify(config));
-    return true;
-  }
-
-  async getConfig(id: string): Promise<VerificationConfig> {
-    const config = (await this.redis.get(id)) as VerificationConfig;
-    return config;
-  }
-}
+import { createConfigStore } from "@/lib/configStore";
 
 export default async function handler(
   req: NextApiRequest,
@@ -49,10 +22,7 @@ export default async function handler(
         });
       }
 
-      const configStore = new KVConfigStore(
-        process.env.KV_REST_API_URL!,
-        process.env.KV_REST_API_TOKEN!
-      );
+      const configStore = createConfigStore();
 
       const selfBackendVerifier = new SelfBackendVerifier(
         "self-playground",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,16 +1,16 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 export default {
   content: [
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
       },
       fontFamily: {
         advercase: ['Advercase', 'sans-serif'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,6 +968,11 @@
     tslib "^2.8.1"
     tsyringe "^4.10.0"
 
+"@pkgr/core@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
+  integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
@@ -2292,6 +2297,11 @@ eslint-config-next@15.1.7:
     eslint-plugin-react "^7.37.0"
     eslint-plugin-react-hooks "^5.0.0"
 
+eslint-config-prettier@^10.1.8:
+  version "10.1.8"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz#15734ce4af8c2778cc32f0b01b37b0b5cd1ecb97"
+  integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
+
 eslint-import-resolver-node@^0.3.6, eslint-import-resolver-node@^0.3.9:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz#d4eaac52b8a2e7c3cd1903eb00f7e053356118ac"
@@ -2321,7 +2331,7 @@ eslint-module-utils@^2.12.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.31.0:
+eslint-plugin-import@^2.31.0, eslint-plugin-import@^2.32.0:
   version "2.32.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz#602b55faa6e4caeaa5e970c198b5c00a37708980"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
@@ -2367,6 +2377,14 @@ eslint-plugin-jsx-a11y@^6.10.0:
     safe-regex-test "^1.0.3"
     string.prototype.includes "^2.0.1"
 
+eslint-plugin-prettier@^5.5.5:
+  version "5.5.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz#9eae11593faa108859c26f9a9c367d619a0769c0"
+  integrity sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==
+  dependencies:
+    prettier-linter-helpers "^1.0.1"
+    synckit "^0.11.12"
+
 eslint-plugin-react-hooks@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz#1be0080901e6ac31ce7971beed3d3ec0a423d9e3"
@@ -2395,6 +2413,11 @@ eslint-plugin-react@^7.37.0:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.12"
     string.prototype.repeat "^1.0.0"
+
+eslint-plugin-simple-import-sort@^12.1.1:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz#e64bfdaf91c5b98a298619aa634a9f7aa43b709e"
+  integrity sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==
 
 eslint-scope@^8.4.0:
   version "8.4.0"
@@ -2550,6 +2573,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
+  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
 fast-glob@3.3.1:
   version "3.3.1"
@@ -3816,6 +3844,18 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier-linter-helpers@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz#6a31f88a4bad6c7adda253de12ba4edaea80ebcd"
+  integrity sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^3.8.1:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.3.tgz#560f2de55bf01b4c0503bc629d5df99b9a1d09b0"
+  integrity sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==
+
 process@^0.11.1:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
@@ -4469,6 +4509,13 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+synckit@^0.11.12:
+  version "0.11.12"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.11.12.tgz#abe74124264fbc00a48011b0d98bdc1cffb64a7b"
+  integrity sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==
+  dependencies:
+    "@pkgr/core" "^0.2.9"
 
 tailwindcss@^3.4.1:
   version "3.4.19"


### PR DESCRIPTION
## Summary

- **Dev-mode in-memory config store.** Abstracted the `IConfigStorage` implementation out of `pages/api/verify.ts` into `lib/configStore.ts`. Adds an `InMemoryConfigStore` that's used automatically when `KV_REST_API_URL` / `KV_REST_API_TOKEN` aren't set, so the app works locally with no Redis setup. Production still requires real credentials (throws otherwise).
- **ESLint + Prettier config** ported from `selfxyz/self`: `.prettierrc`, `.prettierignore`, and a flat-config `eslint.config.mjs` with `simple-import-sort` (selfxyz grouping), `consistent-type-imports`, `no export *`, and prettier integration. Drops RN-only rules.
- **New scripts:** `yarn fmt`, `yarn fmt:fix`, `yarn lint:fix`, `yarn nice` (format + lint fix), `yarn format` alias, `yarn types` (tsc --noEmit).
- **Repo-wide format pass** via `yarn nice` — accounts for most of the churn in `app/components/*` and other existing files.
- `.gitignore`: ignore `.eslintcache`.

## Test plan

- [ ] `yarn install`
- [ ] `yarn types` passes
- [ ] `yarn lint` passes
- [ ] `yarn fmt` passes
- [ ] `yarn dev` with no `KV_*` env vars — saveOptions/verify work against in-memory store; warning logged once
- [ ] `yarn dev` with `KV_REST_API_URL` + `KV_REST_API_TOKEN` set — saveOptions/verify hit Upstash as before