### PR TITLE
Auto-sync staging branch to main on push

### DIFF
--- a/.github/workflows/sync-staging.yml
+++ b/.github/workflows/sync-staging.yml
@@ -1,0 +1,41 @@
+name: Sync staging with main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-staging
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync staging to main
+        run: |
+          git fetch origin staging main
+          behind=$(git rev-list --count origin/staging..origin/main)
+          ahead=$(git rev-list --count origin/main..origin/staging)
+          echo "staging is $behind commits behind, $ahead commits ahead of main"
+
+          if [ "$ahead" != "0" ]; then
+            echo "staging has $ahead unique commits and no longer mirrors main"
+            echo "Realign staging to main before re-running this workflow."
+            exit 1
+          fi
+
+          if [ "$behind" = "0" ]; then
+            echo "staging already matches main"
+            exit 0
+          fi
+
+          git push origin origin/main:refs/heads/staging
+          echo "Updated staging to $(git rev-parse origin/main)"


### PR DESCRIPTION
Adds a GitHub Actions workflow that fast-forwards `staging` to match `main` on every push to `main`.

## Why
`staging` deploys to the staging playground and must mirror `main`, but devs sometimes fix bugs on `main` and forget to bring them over. Manual syncing is the wrong default for a branch that's just a deploy pointer.

## Behavior
- `staging` matches `main`: no-op.
- `staging` is behind `main`: fast-forward push.
- `staging` has commits not on `main`: fail loudly so the divergence gets resolved (rather than papered over with a merge commit).

## Setup notes
- `staging` should not have branch protection that blocks direct pushes from `github-actions[bot]`. It's an automation-owned branch.